### PR TITLE
Fix for nbconvert 4.1.0->4.2.0 behavior changes

### DIFF
--- a/nbflow/scons.py
+++ b/nbflow/scons.py
@@ -4,22 +4,25 @@ import subprocess as sp
 
 import nbconvert
 
-def build_notebook(target, source, env):
-    notebook = str(source[0])
+def build_cmd(notebook):
     cmd = [
         "jupyter", "nbconvert",
         "--log-level=ERROR",
         "--ExecutePreprocessor.timeout=120",
         "--execute",
         "--inplace",
-        "--to", "notebook",
-        notebook
+        "--to", "notebook"
     ]
 
     if nbconvert.__version__ < '4.2.0':
         cmd.extend(['--output', notebook])
+    cmd.append(notebook)
 
-    code = sp.call(cmd)
+    return cmd
+
+def build_notebook(target, source, env):
+    notebook = str(source[0])
+    code = sp.call(build_cmd(notebook))
     if code != 0:
         raise RuntimeError("Error executing notebook")
 

--- a/nbflow/scons.py
+++ b/nbflow/scons.py
@@ -2,6 +2,7 @@ import json
 import sys
 import subprocess as sp
 
+import nbconvert
 
 def build_notebook(target, source, env):
     notebook = str(source[0])
@@ -12,9 +13,12 @@ def build_notebook(target, source, env):
         "--execute",
         "--inplace",
         "--to", "notebook",
-        "--output", notebook,
         notebook
     ]
+
+    if nbconvert.__version__ < '4.2.0':
+        cmd.extend(['--output', notebook])
+
     code = sp.call(cmd)
     if code != 0:
         raise RuntimeError("Error executing notebook")


### PR DESCRIPTION
Addresses issue #4, caused by a change in behavior of the `--inplace` argument between nbconvert versions.