### PR TITLE
Add Tox integration - Merge after #9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ python:
   - 2.7
   - 3.5
   - 3.6
-before_install:
-  - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels ~/travis-wheels
 install:
-  - pip install -U pip setuptools
-  - PIP_FIND_LINKS=~/travis-wheels/wheelhouse pip install -r dev-requirements.txt -e .
+  - pip install tox-travis
 script:
-  - py.test -v -x
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 sudo: false
 python:
   - 2.7
+  - 3.5
+  - 3.6
 before_install:
   - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels ~/travis-wheels
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - 2.7
   - 3.5
   - 3.6
+  - 3.7-dev
 install:
   - pip install tox-travis
 script:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A tool that supports one-button reproducible workflows with the Jupyter Notebook
 
 > **UPDATE: Scons >= 3.0.0 now supports Python 3 so Python 2 isn't needed anymore!** Now Nbflow and Scons are both Python 2 and 3 compatible so you can choose whichever you want.
 
+> The actual version of Scons (3.0.1) currently supports Python >= 3.5, which is the default in Ubuntu 16.04
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
-# nbflow
+# NBFlow
 
 [![Build Status](https://travis-ci.org/jhamrick/nbflow.svg?branch=master)](https://travis-ci.org/jhamrick/nbflow)
 
-A tool that supports one-button reproducible workflows with the Jupyter Notebook and Scons.
-**Note: this currently requires Python 2 (because Scons does not yet support Python 3),
-and currently only supports Python kernels.**
+A tool that supports one-button reproducible workflows with the Jupyter Notebook and Scons. **Note: this currently  only supports Python kernels.**
+
+> **UPDATE: Scons >= 3.0.0 now supports Python 3 so Python 2 isn't needed anymore!** Now Nbflow and Scons are both Python 2 and 3 compatible so you can choose whichever you want.
+
 
 ## Installation
 
 To install, run:
 
+Linux:
 ```
-pip2 install git+git://github.com/jhamrick/nbflow.git
+pip3 install git+git://github.com/jhamrick/nbflow.git
+```
+
+Windows:
+```
+pip install git+git://github.com/jhamrick/nbflow.git
 ```
 
 ## Usage

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,0 @@
--r requirements.txt
-pytest

--- a/nbflow/extractor.py
+++ b/nbflow/extractor.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import os
 import glob
 import json
@@ -11,8 +12,8 @@ from ._version import __version__
 
 class DependencyExtractor(Application):
 
-    name = Unicode(u'nbflow')
-    description = Unicode(u'Extract the hierarchy of dependencies from notebooks in the specified folder.')
+    name = 'nbflow'
+    description = 'Extract the hierarchy of dependencies from notebooks in the specified folder.'
     version = __version__
 
     def extract_parameters(self, nb):
@@ -57,7 +58,7 @@ class DependencyExtractor(Application):
                 sources = [self.resolve_path(filename, x) for x in params['__depends__']]
 
                 targets = params['__dest__']
-                if not hasattr(targets, '__iter__'):
+                if not isinstance(targets, list):
                     if targets is None:
                         targets = []
                     else:

--- a/nbflow/scons.py
+++ b/nbflow/scons.py
@@ -52,7 +52,7 @@ def print_cmd_line(s, targets, sources, env):
 def setup(env, directories):
     env['PRINT_CMD_LINE_FUNC'] = print_cmd_line
     env.Decider('timestamp-newer')
-    DEPENDENCIES = json.loads(sp.check_output([sys.executable, "-m", "nbflow"] + directories))
+    DEPENDENCIES = json.loads(sp.check_output([sys.executable, "-m", "nbflow"] + directories).decode('UTF-8'))
     for script in DEPENDENCIES:
         deps = DEPENDENCIES[script]
         if len(deps['targets']) == 0:

--- a/nbflow/tests/test_nbflow.py
+++ b/nbflow/tests/test_nbflow.py
@@ -4,6 +4,7 @@ import shutil
 
 from textwrap import dedent
 from .util import run_command, clear_notebooks, create_notebook
+import json
 
 
 def test_nbflow_no_args(temp_cwd):
@@ -39,7 +40,7 @@ def test_example(temp_cwd):
         }
         """ % dict(path=os.path.abspath(os.path.realpath(temp_cwd)))
     ).lstrip()
-    assert output == expected
+    assert json.loads(output.decode('UTF-8')) == json.loads(expected)
 
     # try running scons
     output = run_command(["scons"])
@@ -54,7 +55,7 @@ def test_example(temp_cwd):
         """
     ).lstrip()
 
-    assert output == expected
+    assert output == expected.encode('UTF-8')
 
     # run scons again, make sure it doesn't want to do anything
     output = run_command(["scons", "-n"])
@@ -68,7 +69,7 @@ def test_example(temp_cwd):
         """
     ).lstrip()
 
-    assert output == expected
+    assert output == expected.encode('UTF-8')
 
 
 def test_empty_notebook(temp_cwd, sconstruct):
@@ -86,7 +87,7 @@ def test_empty_notebook(temp_cwd, sconstruct):
         """
     ).lstrip()
 
-    assert output == expected
+    assert output == expected.encode('UTF-8')
 
 
 def test_notebook_with_errors(temp_cwd, sconstruct):
@@ -112,7 +113,7 @@ def test_notebook_without_depends(temp_cwd, sconstruct):
         """
     ).lstrip()
 
-    assert output == expected
+    assert output == expected.encode('UTF-8')
 
 
 def test_notebook_without_dest(temp_cwd, sconstruct):
@@ -141,5 +142,5 @@ def test_multiple_notebooks_with_no_dests(temp_cwd, sconstruct):
         """
     ).lstrip()
 
-    assert output == expected
+    assert output == expected.encode('UTF-8')
 

--- a/nbflow/tests/util.py
+++ b/nbflow/tests/util.py
@@ -11,7 +11,7 @@ def run_command(cmd, retcode=0):
     p = sp.Popen(cmd, stdout=sp.PIPE, stderr=sp.STDOUT)
     code = p.wait()
     stdout, _ = p.communicate()
-    stdout = stdout.replace("\x1b[?1034h", "")
+    stdout = stdout.replace(b"\x1b[?1034h", b"")
     if code != retcode:
         print(stdout)
         raise RuntimeError("command returned unexpected code: {}".format(code))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 traitlets
 nbconvert==4.1
-scons
+scons>=3.0.0
 ipykernel

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,8 @@ setup_args = dict(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
     ],
     packages=['nbflow'],
     scripts=['scripts/nbflow'],

--- a/setup.py
+++ b/setup.py
@@ -47,16 +47,13 @@ setup_args = dict(
     scripts=['scripts/nbflow'],
     package_data={
         'nbflow': extension_files
-    }
+    },
+    install_requires=[
+        "traitlets",
+        "nbconvert==4.1",
+        "scons>=3.0.0",
+        "ipykernel",
+    ]
 )
-
-
-setup_args['install_requires'] = install_requires = []
-with open('requirements.txt') as f:
-    for line in f.readlines():
-        req = line.strip()
-        if not req or req.startswith(('-e', '#')):
-            continue
-        install_requires.append(req)
 
 setup(**setup_args)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36
+envlist = py27, py35, py36, py37
 
 [testenv]
 commands = py.test -v -x

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27, py35, py36
+
+[testenv]
+commands = py.test -v -x
+deps = pytest
+       nbconvert
+       scons


### PR DESCRIPTION
Use Tox to automate testing in different virtualenvs with TravisCI. One can use tox to have the same results of TravisCI without needing to push.

- Simplifies travis.yml
- Add tox.ini
- Add Python 3.7-dev test env
- Integrate Tox with TravisCI
- Add install_requires explicitly
- Remove dev-requirements.txt because it's no longer used

This pull request should be merged after #9 in order to work, because it uses Python 3