### PR TITLE
:construction_worker: Add Tox Test System. This replaces #11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ target/
 
 # Scons
 .sconsign.dblite
+
+\.pytest_cache/
+
+MANIFEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ python:
   - 2.7
   - 3.5
   - 3.6
-before_install:
-  - git clone --quiet --depth 1 https://github.com/minrk/travis-wheels ~/travis-wheels
+  - 3.7-dev 
 install:
-  - pip install -U pip setuptools
-  - PIP_FIND_LINKS=~/travis-wheels/wheelhouse pip install -r dev-requirements.txt -e .
+  - pip install tox-travis
 script:
-  - py.test -v -x
+  - tox

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,0 @@
--r requirements.txt
-pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27, py35, py36, py37
+
+[testenv]
+commands = py.test -v -x
+deps = pytest


### PR DESCRIPTION
- Test against multiple Python versions
- Remove unncesary file
- Integrate Tox with Travis and simplify travis.yml
- Add test specific files to gitignore
- Keep setup.py without changes