### PR TITLE
Add Custom Timeout - Closes #8

### DIFF
--- a/nbflow/example/SConstruct
+++ b/nbflow/example/SConstruct
@@ -2,4 +2,8 @@ import os
 from nbflow.scons import setup
 
 env = Environment(ENV=os.environ)
-setup(env, ["analyses"])
+timeout = ARGUMENTS.get('timeout', 0)
+if int(timeout):
+    setup(env, ["analyses"], int(timeout))
+else:
+    setup(env, ["analyses"])

--- a/nbflow/example/SConstruct
+++ b/nbflow/example/SConstruct
@@ -2,8 +2,4 @@ import os
 from nbflow.scons import setup
 
 env = Environment(ENV=os.environ)
-timeout = ARGUMENTS.get('timeout', 0)
-if int(timeout):
-    setup(env, ["analyses"], int(timeout))
-else:
-    setup(env, ["analyses"])
+setup(env, ["analyses"], ARGUMENTS)

--- a/nbflow/example/analyses/analyze_data.ipynb
+++ b/nbflow/example/analyses/analyze_data.ipynb
@@ -26,6 +26,16 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "time.sleep(5) # Simulate long running task"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "metadata": {
     "collapsed": true
    },

--- a/nbflow/scons.py
+++ b/nbflow/scons.py
@@ -4,11 +4,13 @@ import subprocess as sp
 
 import nbconvert
 
+TIMEOUT = "120"
+
 def build_cmd(notebook):
     cmd = [
         "jupyter", "nbconvert",
         "--log-level=ERROR",
-        "--ExecutePreprocessor.timeout=120",
+        "--ExecutePreprocessor.timeout=" + TIMEOUT,
         "--execute",
         "--inplace",
         "--to", "notebook"
@@ -49,9 +51,12 @@ def print_cmd_line(s, targets, sources, env):
             sys.stdout.write("%s --> %s\n"% (str(sources[0]), str(target)))
 
 
-def setup(env, directories):
+def setup(env, directories, timeout=None):
     env['PRINT_CMD_LINE_FUNC'] = print_cmd_line
     env.Decider('timestamp-newer')
+    if timeout is not None:
+        global TIMEOUT
+        TIMEOUT = str(timeout)
     DEPENDENCIES = json.loads(sp.check_output([sys.executable, "-m", "nbflow"] + directories).decode('UTF-8'))
     for script in DEPENDENCIES:
         deps = DEPENDENCIES[script]

--- a/nbflow/scons.py
+++ b/nbflow/scons.py
@@ -1,16 +1,16 @@
 import json
 import sys
 import subprocess as sp
+from functools import partial
 
 import nbconvert
 
-TIMEOUT = "120"
 
-def build_cmd(notebook):
+def build_cmd(notebook, timeout):
     cmd = [
         "jupyter", "nbconvert",
         "--log-level=ERROR",
-        "--ExecutePreprocessor.timeout=" + TIMEOUT,
+        "--ExecutePreprocessor.timeout=" + timeout,
         "--execute",
         "--inplace",
         "--to", "notebook"
@@ -22,9 +22,9 @@ def build_cmd(notebook):
 
     return cmd
 
-def build_notebook(target, source, env):
+def build_notebook(target, source, env, timeout="120"):
     notebook = str(source[0])
-    code = sp.call(build_cmd(notebook))
+    code = sp.call(build_cmd(notebook, timeout))
     if code != 0:
         raise RuntimeError("Error executing notebook")
 
@@ -51,17 +51,19 @@ def print_cmd_line(s, targets, sources, env):
             sys.stdout.write("%s --> %s\n"% (str(sources[0]), str(target)))
 
 
-def setup(env, directories, timeout=None):
+def setup(env, directories, args):
     env['PRINT_CMD_LINE_FUNC'] = print_cmd_line
     env.Decider('timestamp-newer')
-    if timeout is not None:
-        global TIMEOUT
-        TIMEOUT = str(timeout)
     DEPENDENCIES = json.loads(sp.check_output([sys.executable, "-m", "nbflow"] + directories).decode('UTF-8'))
+    timeout = args.get('timeout', None)
+    if timeout is not None:
+        build_notebook_timeout = partial(build_notebook, timeout=str(timeout))
+    else:
+        build_notebook_timeout = build_notebook
     for script in DEPENDENCIES:
         deps = DEPENDENCIES[script]
         if len(deps['targets']) == 0:
             targets = ['.phony_{}'.format(script)]
         else:
             targets = deps['targets']
-        env.Command(targets, [script] + deps['sources'], build_notebook)
+        env.Command(targets, [script] + deps['sources'], build_notebook_timeout)

--- a/nbflow/tests/conftest.py
+++ b/nbflow/tests/conftest.py
@@ -28,6 +28,6 @@ def sconstruct(temp_cwd):
             from nbflow.scons import setup
 
             env = Environment(ENV=os.environ)
-            setup(env, ["."])
+            setup(env, ["."], ARGUMENTS)
             """
         ))

--- a/nbflow/tests/test_nbflow.py
+++ b/nbflow/tests/test_nbflow.py
@@ -11,6 +11,15 @@ def test_nbflow_no_args(temp_cwd):
     run_command([sys.executable, "-m", "nbflow"], retcode=1)
 
 
+def test_notebook_long_excecution(temp_cwd, sconstruct):
+    # copy example files
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "example"))
+    shutil.copytree(os.path.join(root, "analyses"), "analyses")
+    shutil.copy(os.path.join(root, "SConstruct"), "SConstruct")
+    clear_notebooks("analyses")
+
+    run_command(["scons","timeout=1"], retcode=2)
+
 def test_example(temp_cwd):
     # copy example files
     root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "example"))


### PR DESCRIPTION
- Now one can set a timeout either through the scons command or directly in SConstruct. Use either of:
    - Run `scons timeout=TIMEINSECONDS` - This assumes the default SConstruct is used
    - In SConstruct invoke `setup(env, directories, timeout)`
- Add the test for this feature
- Modify example to simulate a long running task with time.sleep