### PR TITLE
Allow nbconvert versions > 4.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 traitlets
-nbconvert==4.1
+nbconvert>=4.1
 scons>=3.0.0
 ipykernel


### PR DESCRIPTION
Currently nbconvert as a dependency is limited to version 4.1 which was introduced here: https://github.com/jhamrick/nbflow/commit/978c71266064ba12fa2cdbced5d54c7701d08864

But in the meantime the chance of version conflicts seems high. With nbconvert 4.1 in a recent notebook project I got:

    lib/python3.5/site-packages/notebook/notebook/handlers.py, line 19, in 
    get_custom_frontend_exporters
    from nbconvert.exporters.base import get_export_names, get_exporter
    ImportError: No module named 'nbconvert.exporters.base'

After manually upgrading with `pip install -U nbconvert` to nbconvert the notebook works again. Pip installed version 5.4 for me.

And nbflow seems to work with nbconvert 5.4 for me, but this is not really tested.
